### PR TITLE
feat!: move html partials to vendor/finkregh/ical/events/

### DIFF
--- a/.github/exampleSite/hugo.toml
+++ b/.github/exampleSite/hugo.toml
@@ -2,15 +2,14 @@ baseURL = 'https://finkregh.github.io/hugo-theme-component-ical/'
 languageCode = 'en-us'
 title = 'Demo of hugo-theme-component-ical'
 
-# required for the CI tests, not required otherwise
-themesDir = '../../..'
-
 [module]
+# replacement pointing to local folder, required to get _this_ variant in the CI
+# not required otherwise
+replacements = 'github.com/finkregh/hugo-theme-component-ical -> ../../..'
+
 # This theme component
 [[module.imports]]
-path = 'hugo-theme-component-ical'
-# Use this in your own site
-# path = 'github.com/finkregh/hugo-theme-component-ical'
+path = 'github.com/finkregh/hugo-theme-component-ical'
 
 # The base theme for the demo site
 [[module.imports]]

--- a/.github/exampleSite/layouts/_default/baseof.html
+++ b/.github/exampleSite/layouts/_default/baseof.html
@@ -18,12 +18,9 @@
   */}}
   <script>(function(C){C.remove('no-js');C.add('js')})(document.documentElement.classList)</script>
 
-  <!-- Start calendar javascript -->
-    {{ if and (.OutputFormats.Get "Calendar") (eq .Type "events") }}
-    <meta http-equiv="Content-Security-Policy" content="font-src data:" />
-    {{ partial "events/javascript.html" . }}
-    {{ end }}
-<!-- End calendar javascript -->
+  <!-- Begin calendar javascript -->
+  {{ partial "vendor/finkregh/ical/js.html" . }}
+  <!-- End calendar javascript -->
 
   <title>
     {{ if .IsHome }}{{ (site.Title | .Page.RenderString) }}{{ else }}{{ ((printf "%s | %s" .Title site.Title) | .Page.RenderString) }}{{ end }}

--- a/.github/workflows/validate-ical.yml
+++ b/.github/workflows/validate-ical.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run tests with just
         env:
             JUST_COLOR: always
-        run: just test
+        run: just test_debug
 
       - name: List generated files
         run: |

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ localserve_build:  hugo_go_modules build_hugo_localhost
 
 [working-directory: '.github/exampleSite']
 hugo_go_modules:
-    hugo mod get -u ./...
+    hugo mod get ./...
     hugo mod tidy
     hugo mod npm pack
     npm update
@@ -21,10 +21,11 @@ build_hugo:
 
 [working-directory: '.github/exampleSite']
 build_hugo_debug:
-    hugo build --logLevel debug --cleanDestinationDir --baseURL https://finkregh.github.io/hugo-theme-component-ical/
+    hugo build --cleanDestinationDir --printPathWarnings --printUnusedTemplates --printI18nWarnings --logLevel debug --buildDrafts --templateMetrics --templateMetricsHints --environment testing --baseURL https://finkregh.github.io/hugo-theme-component-ical/
 
+[working-directory: '.github/exampleSite']
 build_hugo_localhost:
-    hugo build --baseURL https://localhost:4443/ --cleanDestinationDir
+    hugo build --cleanDestinationDir --printPathWarnings --printUnusedTemplates --printI18nWarnings --logLevel debug --buildDrafts --templateMetrics --templateMetricsHints --environment testing --baseURL https://localhost:4443/
 
 [working-directory: '.github']
 run_ics_validation: build_hugo

--- a/layouts/_partials/events/javascript-inline.html
+++ b/layouts/_partials/events/javascript-inline.html
@@ -1,4 +1,0 @@
-    {{ $defines := dict "process.env.NODE_ENV" "production" }}
-    {{ $options := dict "targetPath" "js/vendor/finkregh/ical/minified.js" "defines" $defines }}
-    {{ $built := resources.Get "js/vendor/finkregh/ical/script.js" | js.Build $options | resources.Minify | resources.Fingerprint "sha256"}}
-    <script type="module" defer>{{ $built.Content }}</script>

--- a/layouts/_partials/events/javascript.html
+++ b/layouts/_partials/events/javascript.html
@@ -1,4 +1,0 @@
-    {{ $defines := dict "process.env.NODE_ENV" "production" }}
-    {{ $options := dict "targetPath" "js/vendor/finkregh/ical/minified.js" "defines" $defines }}
-    {{ $built := resources.Get "js/vendor/finkregh/ical/script.js" | js.Build $options | resources.Minify | resources.Fingerprint "sha256"}}
-    <script src="{{ $built.Permalink }}" type="module" integrity="{{ $built.Data.Integrity }}" defer></script>

--- a/layouts/_partials/vendor/finkregh/ical/js-inline.html
+++ b/layouts/_partials/vendor/finkregh/ical/js-inline.html
@@ -1,0 +1,11 @@
+{{ if and (.OutputFormats.Get "Calendar") (eq .Type "events") }}
+{{- $isProd := hugo.IsProduction -}}
+{{ if not $isProd }}<!-- BEGIN block from {{ templates.Current.Filename }} -->{{ end }}
+<meta http-equiv="Content-Security-Policy" content="font-src data:" />
+
+{{ $defines := dict "process.env.NODE_ENV" "production" }}
+{{ $options := dict "targetPath" "js/vendor/finkregh/ical/minified.js" "defines" $defines }}
+{{ $js := resources.Get "js/vendor/finkregh/ical/script.js" | js.Build $options | resources.Minify | resources.Fingerprint "sha256"}}
+<script type="module" defer>{{ $js.Content }}</script>
+{{ if not $isProd }}<!-- END block from {{ templates.Current.Filename }} -->{{ end }}
+{{ end }}

--- a/layouts/_partials/vendor/finkregh/ical/js.html
+++ b/layouts/_partials/vendor/finkregh/ical/js.html
@@ -1,0 +1,11 @@
+{{ if and (.OutputFormats.Get "Calendar") (eq .Type "events") }}
+{{- $isProd := hugo.IsProduction -}}
+{{ if not $isProd }}<!-- BEGIN block from {{ templates.Current.Filename }} -->{{ end }}
+<meta http-equiv="Content-Security-Policy" content="font-src data:" />
+
+{{ $defines := dict "process.env.NODE_ENV" "production" }}
+{{ $options := dict "targetPath" "js/vendor/finkregh/ical/minified.js" "defines" $defines }}
+{{ $js := resources.Get "js/vendor/finkregh/ical/script.js" | js.Build $options | resources.Minify | resources.Fingerprint "sha256"}}
+<script type="module" src="{{ $js.Permalink }}" {{ if $isProd }}integrity="{{ $js.Data.Integrity }}"{{ end }} defer></script>
+{{ if not $isProd }}<!-- END block from {{ templates.Current.Filename }} -->{{ end }}
+{{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -1,0 +1,12 @@
+name = "hugo-theme-component-ical"
+description = "A Hugo theme component to generate iCalendar files."
+homepage = "https://github.com/finkregh/hugo-theme-component-ical"
+demosite = "https://finkregh.github.io/hugo-theme-component-ical/"
+
+license = "GPL-3.0-or-later"
+licenselink = "https://github.com/finkregh/hugo-theme-component-ical/blob/main/LICENSE"
+authors = [{ name = "Oluf Lorenzen", homepage = "https://oluflorenzen.de" }]
+
+tags = ["ical", "icalendar", "component"]
+features = ["minimalist"]
+min_version = "0.146.0"


### PR DESCRIPTION
- no more html files directly in `layouts/`
- extend readme
- add `<meta http-equiv="Content-Security-Policy" content="font-src data:" />` in partials